### PR TITLE
new test and null check fix

### DIFF
--- a/NuGet.Extensions.Tests/FeedAudit/GacResolverTests.cs
+++ b/NuGet.Extensions.Tests/FeedAudit/GacResolverTests.cs
@@ -13,6 +13,7 @@ namespace NuGet.Extensions.Tests.FeedAudit
         [TestCase("System", Result = true, Description = "Can resolve System")]
         [TestCase("Giberishshsidfasdfasdfasdf.asdfasdfas.dasdfasdf", Result = false, Description = "Cant resolve gibberish")]
         [TestCase("System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", Result = true, Description = "Using full name")]
+        [TestCase("System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null, ProcessorArchitecture=MSIL", Result = true, Description = "Using full name")]
         public bool CanResolveSystem(string assemblyName)
         {
             string test;

--- a/NuGet.Extensions/Commands/Audit.cs
+++ b/NuGet.Extensions/Commands/Audit.cs
@@ -60,7 +60,7 @@ namespace NuGet.Extensions.Commands
         public override void ExecuteCommand()
         {
             var excludedPackageIds = GetLowerInvariantExcludedPackageIds();
-            var excludedWildcards = GetExcludedWildcards(Exceptions);
+            var excludedWildcards = String.IsNullOrEmpty(Exceptions) ? new List<Regex>() : GetExcludedWildcards(Exceptions);
             var repository = GetRepository();
             var feedAuditor = new FeedAuditor(repository, excludedPackageIds, excludedWildcards, Unlisted, CheckFeedForUnresolvedAssemblies, Gac);
             feedAuditor.StartPackageAudit += (o, e) => Console.WriteLine("Starting audit of package: {0}", e.Package.Id);
@@ -91,6 +91,7 @@ namespace NuGet.Extensions.Commands
                 {
                     writer.WriteLine("\t{0}", assembly.FullName);
                 }
+                writer.Close();
                 //TODO this is pretty ugly, perhaps need to look at what we are providing as part of the UnresolvableAssemblyReferences
                 //HACK the code below is duplicated in two places, ugly.
                 if (Verbose)


### PR DESCRIPTION
added that new test where fails because publicKey is null (still need to fix)
fix where nullException occurs because Exceptions string is null
close streamwriter
