### PR TITLE
GAC Flag Functionality Update - Adds GAC Assemblies to Default Output.

### DIFF
--- a/NuGet.Extensions/Commands/Audit.cs
+++ b/NuGet.Extensions/Commands/Audit.cs
@@ -83,7 +83,7 @@ namespace NuGet.Extensions.Commands
                 else
                     throw new ApplicationException(string.Format("Could not find package locally or on feed: {0}",Package));
             }
-            var auditFlags = GetAuditFlags(RunTimeFailOnly, CheckFeedForUnresolvedAssemblies, Gac);
+            var auditFlags = GetAuditFlags(RunTimeFailOnly, CheckFeedForUnresolvedAssemblies);
             var outputer = new FeedAuditResultsOutputManager(results, auditFlags);
             outputer.Output(string.IsNullOrEmpty(Output) ? System.Console.Out : new StreamWriter(Path.GetFullPath(Output)));
 
@@ -113,25 +113,24 @@ namespace NuGet.Extensions.Commands
             return new List<Regex>(wildcards.Select(w => new Wildcard(w)));
         }
 
-        private static AuditEventTypes GetAuditFlags(bool runTimeOnly, bool checkFeedResolvable, bool gac)
+        private static AuditEventTypes GetAuditFlags(bool runTimeOnly, bool checkFeedResolvable)
         {
             var events = (AuditEventTypes) 0;
-            if (runTimeOnly || checkFeedResolvable || gac)
+            if (runTimeOnly || checkFeedResolvable)
             {
                 if (runTimeOnly)
                     events |= AuditEventTypes.UnresolvedAssemblyReferences;
                 if (checkFeedResolvable)
                     events |= AuditEventTypes.FeedResolvableReferences;
-                if (gac)
-                    events |= AuditEventTypes.GacResolvableReferences;
                 return events;
             }
-            return AuditEventTypes.ResolvedAssemblyReferences
-                   | AuditEventTypes.UnloadablePackageFiles
-                   | AuditEventTypes.UnresolvedAssemblyReferences
-                   | AuditEventTypes.UnresolvedDependencies
-                   | AuditEventTypes.UnusedPackageDependencies
-                   | AuditEventTypes.UsedPackageDependencies;
+			return AuditEventTypes.ResolvedAssemblyReferences
+					| AuditEventTypes.UnloadablePackageFiles
+					| AuditEventTypes.UnresolvedAssemblyReferences
+					| AuditEventTypes.UnresolvedDependencies
+					| AuditEventTypes.UnusedPackageDependencies
+					| AuditEventTypes.UsedPackageDependencies
+					| AuditEventTypes.GacResolvableReferences;
         }
 
         private static bool CheckPossibleRuntimeFailures(IEnumerable<FeedAuditResult> results)

--- a/NuGet.Extensions/FeedAudit/FeedAuditor.cs
+++ b/NuGet.Extensions/FeedAudit/FeedAuditor.cs
@@ -99,19 +99,12 @@ namespace NuGet.Extensions.FeedAudit
                     usedDependencies.AddRange(possibles.Select(p => p));
                     if (!possibles.Any())
                     {
-                        currentResult.UnresolvedAssemblyReferences.Add(actualDependency);
-                        if (_checkForFeedResolvableAssemblies)
-                        {
-                            //May be expensive....
-                            if (GetPossiblePackagesForAssembly(actualDependency, _feedPackages).Any())
-                                currentResult.FeedResolvableReferences.Add(actualDependency);
-                        }
-
-                        if (_checkGac)
-                        {
-                            if (CanResolveToGac(actualDependency.FullName) || CanResolveToGac(actualDependency.Name))
-                                currentResult.GacResolvableReferences.Add(actualDependency);
-                        }
+						if (_checkForFeedResolvableAssemblies && GetPossiblePackagesForAssembly(actualDependency, _feedPackages).Any())
+							currentResult.FeedResolvableReferences.Add(actualDependency); //May be expensive....
+						else if (_checkGac && (CanResolveToGac(actualDependency.FullName) || CanResolveToGac(actualDependency.Name)))
+							currentResult.GacResolvableReferences.Add(actualDependency);
+						else
+							currentResult.UnresolvedAssemblyReferences.Add(actualDependency);
                     }
                     else
                         currentResult.ResolvedAssemblyReferences.Add(actualDependency);


### PR DESCRIPTION
Updated so GAC flag does not ouput GAC Resolvable References only to a output. Instead it now outputs to the default output but where it was previously "Unresolved Assembly" it becomes "GAC Resolvable Assembly".
