### PR TITLE
Fixed bug in RemoveAssemblyExclusions causing the error: "Fixed Collection was modified; enumeration operation may not execute."

### DIFF
--- a/NuGet.Extensions/FeedAudit/FeedAuditor.cs
+++ b/NuGet.Extensions/FeedAudit/FeedAuditor.cs
@@ -123,8 +123,9 @@ namespace NuGet.Extensions.FeedAudit
 
         private IEnumerable<AssemblyName> RemoveAssemblyExclusions(IEnumerable<AssemblyName> actualAssemblyReferences, PackageAuditResult currentResult)
         {
-            var assemblyReferences = new List<AssemblyName>(actualAssemblyReferences);
-            foreach (var assembly in assemblyReferences)
+	        var actualAssemblyReferencesList = actualAssemblyReferences.ToList();
+			var assemblyReferences = new List<AssemblyName>(actualAssemblyReferencesList);
+			foreach (var assembly in actualAssemblyReferencesList)
             {
                 if (_assemblyWildcards.Any(w => w.IsMatch(assembly.Name.ToLowerInvariant())))
                 {


### PR DESCRIPTION
Fix the "Fixed Collection was modified; enumeration operation may not execute." bug. This bug was caused by the list looping over itself whilst also removing items from itself.
