### PR TITLE
Issue #22 - Feed Audit - Not Resolving Intra Package Dependencies

### DIFF
--- a/NuGet.Extensions/FeedAudit/FeedAuditor.cs
+++ b/NuGet.Extensions/FeedAudit/FeedAuditor.cs
@@ -180,7 +180,7 @@ namespace NuGet.Extensions.FeedAudit
         private static IEnumerable<AssemblyName> RemoveInternallySatisfiedDependencies(IEnumerable<AssemblyName> actualAssemblyReferences, IPackage package)
         {
             var fileNames = GetFileInfoListFromPackageFiles(package);
-            return actualAssemblyReferences.Where(a => !fileNames.Contains(a.Name + ".dll") && !fileNames.Contains(a.Name + ".exe"));
+            return actualAssemblyReferences.Where(a => !fileNames.Contains(a.Name.ToLowerInvariant() + ".dll") && !fileNames.Contains(a.Name.ToLowerInvariant() + ".exe"));
         }
 
         private static List<string> GetFileInfoListFromPackageFiles(IPackage package)


### PR DESCRIPTION
The bug was due the a difference in case during comparison.

The GetFileInfoListFromPackageFiles method inside the FeedAuditor returned all files as lowercase. However when comparison was done with other file in the pakcage, it was using the default casing. This fix simply converts the package filenames to lowercase for the comparison.
