### PR TITLE
Nugetify advanced use cases

### DIFF
--- a/NuGet.Extensions.Tests/MSBuild/AdapterTests.cs
+++ b/NuGet.Extensions.Tests/MSBuild/AdapterTests.cs
@@ -71,6 +71,7 @@ namespace NuGet.Extensions.Tests.MSBuild
             var conditionTrueReferences = emptyConfigurationDependencies.Where(r => r.Condition).Select(r => r.AssemblyName).ToArray();
             var conditionFalseReferences = emptyConfigurationDependencies.Where(r => !r.Condition).Select(r => r.AssemblyName).ToArray();
             Assert.That(conditionTrueReferences, Contains.Item("AssemblyReferencedWhenConfigurationNotEqualsRelease"));
+            Assert.That(conditionFalseReferences.Single(), Is.EqualTo("AssemblyReferencedWhenConfigurationEqualsRelease"));
         }
 
         [Test]
@@ -80,6 +81,7 @@ namespace NuGet.Extensions.Tests.MSBuild
             var conditionTrueReferences = emptyConfigurationDependencies.Where(r => r.Condition).Select(r => r.AssemblyName).ToArray();
             var conditionFalseReferences = emptyConfigurationDependencies.Where(r => !r.Condition).Select(r => r.AssemblyName).ToArray();
             Assert.That(conditionTrueReferences, Contains.Item("AssemblyReferencedWhenConfigurationEqualsRelease"));
+            Assert.That(conditionFalseReferences.Single(), Is.EqualTo("AssemblyReferencedWhenConfigurationNotEqualsRelease"));
         }
         
         public IEnumerable<IReference> GetReferencesForProjectWithDependencies(IDictionary<string, string> globalMsBuildProperties)

--- a/NuGet.Extensions.Tests/MSBuild/AdapterTests.cs
+++ b/NuGet.Extensions.Tests/MSBuild/AdapterTests.cs
@@ -129,7 +129,7 @@ namespace NuGet.Extensions.Tests.MSBuild
         {
             var binaryDependency = _projectBinaryReferenceAdapters.Single(IsExpectedBinaryDependency);
 
-            var isForCorrespondingAssembly = binaryDependency.IsForAssembly(ExpectedBinaryDependencyAssemblyName + ".dll");
+            var isForCorrespondingAssembly = binaryDependency.AssemblyFilenameEquals(ExpectedBinaryDependencyAssemblyName + ".dll");
 
             Assert.That(isForCorrespondingAssembly, Is.True);
         }
@@ -139,7 +139,7 @@ namespace NuGet.Extensions.Tests.MSBuild
         {
             var binaryDependency = _projectBinaryReferenceAdapters.Single(IsExpectedBinaryDependency);
 
-            var isForBlankAssemblyName = binaryDependency.IsForAssembly("") || binaryDependency.IsForAssembly(".dll");
+            var isForBlankAssemblyName = binaryDependency.AssemblyFilenameEquals("") || binaryDependency.AssemblyFilenameEquals(".dll");
 
             Assert.That(isForBlankAssemblyName, Is.False);
         }

--- a/NuGet.Extensions.Tests/ReferenceAnalysers/HintPathGeneratorTests.cs
+++ b/NuGet.Extensions.Tests/ReferenceAnalysers/HintPathGeneratorTests.cs
@@ -25,6 +25,21 @@ namespace NuGet.Extensions.Tests.ReferenceAnalysers
 
             var hintpath = hpg.ForAssembly(solutionDirInfo, projectDirInfo, package, "any.dll");
 
+            Assert.That(hintpath, Is.EqualTo("..\\packages\\any.0.0.0\\any.dll"));
+        }
+
+        [Test]
+        public void HintPathGeneratedWithExcludeVersionDoesNotContainVersion()
+        {
+            var hpg = new HintPathGenerator(false);
+            var solutionDirectory = "c:\\solutionDirectoryWithoutTrailingSlash";
+            var projectDirName = "projectDirectoryWithoutTrailingSlash";
+            var solutionDirInfo = new DirectoryInfo(solutionDirectory);
+            var projectDirInfo = new DirectoryInfo(solutionDirectory + string.Format("\\{0}", projectDirName));
+            var package = PackageUtility.CreatePackage("any", "0.0.0", assemblyReferences: new[] { "any.dll" });
+
+            var hintpath = hpg.ForAssembly(solutionDirInfo, projectDirInfo, package, "any.dll");
+
             Assert.That(hintpath, Is.EqualTo("..\\packages\\any\\any.dll"));
         }
     }

--- a/NuGet.Extensions.Tests/ReferenceAnalysers/ProjectReferenceTestData.cs
+++ b/NuGet.Extensions.Tests/ReferenceAnalysers/ProjectReferenceTestData.cs
@@ -29,8 +29,9 @@ namespace NuGet.Extensions.Tests.ReferenceAnalysers
 
             var dependency = new Mock<IReference>();
             dependency.SetupGet(d => d.AssemblyName).Returns(Path.GetFileNameWithoutExtension(includeFilename));
+            dependency.SetupGet(d => d.AssemblyFilename).Returns(includeFilename);
             dependency.SetupGet(d => d.AssemblyVersion).Returns(includeVersion ?? "0.0.0.0");
-            dependency.Setup(d => d.IsForAssembly(includeFilename)).Returns(true);
+            dependency.Setup(d => d.AssemblyFilenameEquals(includeFilename)).Returns(true);
 
             string anydependencyHintpath = includeFilename;
             dependency.Setup(d => d.TryGetHintPath(out anydependencyHintpath)).Returns(hasHintpath);

--- a/NuGet.Extensions.Tests/ReferenceAnalysers/ReferenceNugetifierBinaryTests.cs
+++ b/NuGet.Extensions.Tests/ReferenceAnalysers/ReferenceNugetifierBinaryTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using Moq;
 using NuGet.Extensions.Tests.Mocks;
 using NUnit.Framework;
@@ -59,6 +61,26 @@ namespace NuGet.Extensions.Tests.ReferenceAnalysers
             var nugetifier = ReferenceNugetifierTester.BuildNugetifier(vsProject: projectWithSingleDependency, packageRepository: packageRepositoryWithCorrespondingPackage);
             ReferenceNugetifierTester.NugetifyReferencesInProject(nugetifier);
             singleDependency.Verify(binaryDependency => binaryDependency.ConvertToNugetReferenceWithHintPath(It.IsAny<string>()), Times.Once());
+        }
+
+        [TestCase("net40")]
+        [TestCase("net35-client")]
+        [TestCase(null)]
+        public void TargetFrameworkAppearsInPackagesConfig(string targetFrameworkString)
+        {
+            FrameworkName targetFramework = targetFrameworkString != null ? VersionUtility.ParseFrameworkName(targetFrameworkString) : null;
+            var singleDependency = ProjectReferenceTestData.ConstructMockDependency();
+            var projectWithSingleDependency = ProjectReferenceTestData.ConstructMockProject(new[] { singleDependency.Object });
+            var packageRepositoryWithCorrespondingPackage = ProjectReferenceTestData.CreateMockRepository();
+            var projectFileSystem = new MockFileSystem();
+            var nugetifier = ReferenceNugetifierTester.BuildNugetifier(vsProject: projectWithSingleDependency, packageRepository: packageRepositoryWithCorrespondingPackage, projectFileSystem: projectFileSystem);
+
+            ReferenceNugetifierTester.AddReferenceMetadata(nugetifier, targetFrameWork: targetFramework);
+
+            var packageConfigs = projectFileSystem.Paths.Select(pathAndData => new PackageReferenceFile(projectFileSystem, pathAndData.Key));
+            var packageReferences = packageConfigs.SelectMany(config => config.GetPackageReferences()).ToList();
+            Assert.That(packageReferences, Is.Not.Empty);
+            Assert.That(packageReferences, Has.All.Matches<PackageReference>(x => Equals(targetFramework, x.TargetFramework)));
         }
 
         [Test]

--- a/NuGet.Extensions.Tests/ReferenceAnalysers/ReferenceNugetifierBinaryTests.cs
+++ b/NuGet.Extensions.Tests/ReferenceAnalysers/ReferenceNugetifierBinaryTests.cs
@@ -45,7 +45,21 @@ namespace NuGet.Extensions.Tests.ReferenceAnalysers
             var packageRepositoryWithOnePackage = ProjectReferenceTestData.CreateMockRepository();
 
             var nugetifier = ReferenceNugetifierTester.BuildNugetifier(vsProject: projectWithSingleDependency, packageRepository: packageRepositoryWithOnePackage);
-            var nugettedDependencies = ReferenceNugetifierTester.AddReferenceMetadata(nugetifier);
+            var nugettedDependencies = ReferenceNugetifierTester.NugetifyReferencesInProject(nugetifier);
+
+            Assert.That(nugettedDependencies, Is.Not.Empty);
+            Assert.That(nugettedDependencies.Single().Id, Contains.Substring(ProjectReferenceTestData.PackageInRepository));
+        }
+
+        [Test]
+        public void PackageFoundForDependencyWithNoHintPath()
+        {
+            var singleDependency = ProjectReferenceTestData.ConstructMockDependency(hasHintpath: false);
+            var projectWithSingleDependency = ProjectReferenceTestData.ConstructMockProject(new[] { singleDependency.Object });
+            var packageRepositoryWithOnePackage = ProjectReferenceTestData.CreateMockRepository();
+
+            var nugetifier = ReferenceNugetifierTester.BuildNugetifier(vsProject: projectWithSingleDependency, packageRepository: packageRepositoryWithOnePackage);
+            var nugettedDependencies = ReferenceNugetifierTester.NugetifyReferencesInProject(nugetifier);
 
             Assert.That(nugettedDependencies, Is.Not.Empty);
             Assert.That(nugettedDependencies.Single().Id, Contains.Substring(ProjectReferenceTestData.PackageInRepository));

--- a/NuGet.Extensions.Tests/ReferenceAnalysers/ReferenceNugetifierTester.cs
+++ b/NuGet.Extensions.Tests/ReferenceAnalysers/ReferenceNugetifierTester.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using Moq;
 using NuGet.Common;
 using NuGet.Extensions.MSBuild;
@@ -12,12 +13,12 @@ namespace NuGet.Extensions.Tests.ReferenceAnalysers
 {
     public class ReferenceNugetifierTester 
     {
-        public static List<IPackage> AddReferenceMetadata(ProjectNugetifier nugetifier, Mock<ISharedPackageRepository> repositoriesConfig = null, DirectoryInfo solutionDir = null)
+        public static List<IPackage> AddReferenceMetadata(ProjectNugetifier nugetifier, Mock<ISharedPackageRepository> repositoriesConfig = null, DirectoryInfo solutionDir = null, FrameworkName targetFrameWork = null)
         {
             var sharedPackageRepository = repositoriesConfig ?? new Mock<ISharedPackageRepository>();
             solutionDir = solutionDir ?? GetMockDirectory();
             var packages = nugetifier.NugetifyReferences(solutionDir);
-            nugetifier.AddNugetReferenceMetadata(sharedPackageRepository.Object, packages);
+            nugetifier.AddNugetReferenceMetadata(sharedPackageRepository.Object, packages, targetFrameWork);
             return packages.ToList();
         }
 

--- a/NuGet.Extensions/Commands/Nugetify.cs
+++ b/NuGet.Extensions/Commands/Nugetify.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Extensions.MSBuild;
@@ -30,6 +31,9 @@ namespace NuGet.Extensions.Commands
 
         [Option("Comma separated list of key=value pairs of parameters to be used when loading projects, note that SolutionDir is automatically set.")]
         public string MsBuildProperties { get; set; }
+
+        [Option("Format as in the packages.config file: {framework}{version}-{profile}")]
+        public string TargetFramework { get; set; }
 
         [Option("NuSpec project URL")]
         public string ProjectUrl { get; set; }
@@ -111,9 +115,10 @@ namespace NuGet.Extensions.Commands
 
         private void NugetifyProject(IVsProject projectAdapter, DirectoryInfo solutionRoot, ISharedPackageRepository existingSolutionPackagesRepo)
         {
+            var targetFramework = TargetFramework != null ? VersionUtility.ParseFrameworkName(TargetFramework) : null;
             var projectNugetifier = CreateProjectNugetifier(projectAdapter);
             var packagesAdded = projectNugetifier.NugetifyReferences(solutionRoot);
-            projectNugetifier.AddNugetReferenceMetadata(existingSolutionPackagesRepo, packagesAdded);
+            projectNugetifier.AddNugetReferenceMetadata(existingSolutionPackagesRepo, packagesAdded, targetFramework);
             projectAdapter.Save();
 
             if (NuSpec)
@@ -121,7 +126,7 @@ namespace NuGet.Extensions.Commands
                 var manifestDependencies = projectNugetifier.GetManifestDependencies(packagesAdded);
                 var nuspecBuilder = new NuspecBuilder(projectAdapter.AssemblyName);
                 nuspecBuilder.SetMetadata(this, manifestDependencies);
-                nuspecBuilder.SetDependencies(manifestDependencies);
+                nuspecBuilder.SetDependencies(manifestDependencies, TargetFramework);
                 nuspecBuilder.Save(Console);
             }
         }

--- a/NuGet.Extensions/Commands/Nugetify.cs
+++ b/NuGet.Extensions/Commands/Nugetify.cs
@@ -35,6 +35,9 @@ namespace NuGet.Extensions.Commands
         [Option("Format as in the packages.config file: {framework}{version}-{profile}")]
         public string TargetFramework { get; set; }
 
+        [Option("Use hint paths that don't contain the package version")]
+        public bool ExcludeVersion { get; set; }
+
         [Option("NuSpec project URL")]
         public string ProjectUrl { get; set; }
 
@@ -136,7 +139,7 @@ namespace NuGet.Extensions.Commands
             var projectFileSystem = new PhysicalFileSystem(projectAdapter.ProjectDirectory.ToString());
             var repository = AggregateRepositoryHelper.CreateAggregateRepositoryFromSources(RepositoryFactory, SourceProvider, Source);
             repository.Logger = Console;
-            var hintPathGenerator = new HintPathGenerator();
+            var hintPathGenerator = new HintPathGenerator(!ExcludeVersion);
             return new ProjectNugetifier(projectAdapter, repository, projectFileSystem, Console, hintPathGenerator);
         }
 

--- a/NuGet.Extensions/MSBuild/BinaryReferenceAdapter.cs
+++ b/NuGet.Extensions/MSBuild/BinaryReferenceAdapter.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Build.Evaluation;
+using NuGet.Extensions.ReferenceAnalysers;
 
 namespace NuGet.Extensions.MSBuild
 {
@@ -31,6 +32,11 @@ namespace NuGet.Extensions.MSBuild
             _reference.SetMetadataValue("HintPath", hintPath);
         }
 
+        public bool AssemblyFilenameEquals(string filename)
+        {
+            return string.Equals(filename, AssemblyFilename, StringComparison.OrdinalIgnoreCase);
+        }
+
         public string AssemblyVersion
         {
             get { return _reference.EvaluatedInclude.Contains(',') ? _reference.EvaluatedInclude.Split(',')[1].Split('=')[1] : null; }
@@ -41,17 +47,20 @@ namespace NuGet.Extensions.MSBuild
             get { return _reference.EvaluatedInclude.Contains(',') ? _reference.EvaluatedInclude.Split(',')[0] : _reference.EvaluatedInclude; }
         }
 
-        public bool IsForAssembly(string assemblyFilename)
+        public string AssemblyFilename
         {
-            string hintpath;
-
-            if (TryGetHintPath(out hintpath))
+            get
             {
-                var fileInfo = new FileInfo(hintpath);
-                return fileInfo.Name.Equals(assemblyFilename, StringComparison.OrdinalIgnoreCase);
+                string hintPath;
+                if (TryGetHintPath(out hintPath))
+                {
+                    return Path.GetFileName(hintPath);
+                }
+                else
+                {
+                    return AssemblyName + ".dll";
+                }
             }
-
-            return false;
         }
 
         public bool Condition { get; private set; }

--- a/NuGet.Extensions/MSBuild/IReference.cs
+++ b/NuGet.Extensions/MSBuild/IReference.cs
@@ -4,12 +4,14 @@ namespace NuGet.Extensions.MSBuild
         string AssemblyVersion { get; }
         string AssemblyName { get; }
         bool Condition { get; }
-        bool IsForAssembly(string assemblyFilename);
+        string AssemblyFilename { get; }
         bool TryGetHintPath(out string hintPath);
 
         /// <summary>
         /// Note: The parent project must be saved in order for this change to persist
         /// </summary>
         void ConvertToNugetReferenceWithHintPath(string hintPath);
+
+        bool AssemblyFilenameEquals(string filename);
     }
 }

--- a/NuGet.Extensions/MSBuild/ProjectAdapter.cs
+++ b/NuGet.Extensions/MSBuild/ProjectAdapter.cs
@@ -22,8 +22,9 @@ namespace NuGet.Extensions.MSBuild
         public IEnumerable<IReference> GetBinaryReferences()
         {
             const string itemType = "Reference";
+            var allBinaryReferences = _project.GetItemsIgnoringCondition(itemType);
             var conditionTrueReferences = new HashSet<ProjectItem>(_project.GetItems(itemType));
-            return conditionTrueReferences.Select(r => new BinaryReferenceAdapter(r, true));
+            return allBinaryReferences.Select(r => new BinaryReferenceAdapter(r, conditionTrueReferences.Contains(r)));
         }
 
         public string AssemblyName
@@ -61,9 +62,9 @@ namespace NuGet.Extensions.MSBuild
 
         public IEnumerable<IReference> GetProjectReferences()
         {
-            const string itemType = "ProjectReference";
-            var conditionTrueProjectReferences = new HashSet<ProjectItem>(_project.GetItems(itemType));
-            return conditionTrueProjectReferences.Select(r => GetProjectReferenceAdapter(r, true));
+            var allrojectReferences = _project.GetItemsIgnoringCondition("ProjectReference");
+            var conditionTrueProjectReferences = new HashSet<ProjectItem>(_project.GetItems("ProjectReference"));
+            return allrojectReferences.Select(r => GetProjectReferenceAdapter(r, conditionTrueProjectReferences.Contains(r)));
         }
 
         private ProjectReferenceAdapter GetProjectReferenceAdapter(ProjectItem r, bool conditionTrue)

--- a/NuGet.Extensions/MSBuild/ProjectReferenceAdapter.cs
+++ b/NuGet.Extensions/MSBuild/ProjectReferenceAdapter.cs
@@ -43,9 +43,14 @@ namespace NuGet.Extensions.MSBuild
 
         public bool Condition { get; private set; }
 
-        public bool IsForAssembly(string assemblyFilename)
+        public string AssemblyFilename
         {
-            return (AssemblyName + ".dll").Equals(assemblyFilename, StringComparison.OrdinalIgnoreCase);
+            get { return AssemblyName + ".dll"; }
+        }
+
+        public bool AssemblyFilenameEquals(string filename)
+        {
+            return string.Equals(filename, AssemblyFilename, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/NuGet.Extensions/NuGet.Extensions.csproj
+++ b/NuGet.Extensions/NuGet.Extensions.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Packages\PackageEnumerator.cs" />
     <Compile Include="Packages\PackageResolutionManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReferenceAnalysers\PublicKeyTokens.cs" />
     <Compile Include="Repositories\AssemblyToPackageMapping.cs" />
     <Compile Include="Repositories\IRepositoryEnumerator.cs" />
     <Compile Include="Repositories\IRepositoryManager.cs" />

--- a/NuGet.Extensions/Nuspec/NuspecBuilder.cs
+++ b/NuGet.Extensions/Nuspec/NuspecBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using NuGet.Common;
 
@@ -54,13 +55,10 @@ namespace NuGet.Extensions.Nuspec
             if (!String.IsNullOrEmpty(nuspecData.ReleaseNotes)) metadata.ReleaseNotes = nuspecData.ReleaseNotes;
         }
 
-        public void SetDependencies(ICollection<ManifestDependency> manifestDependencies, string targetFramework = ".NET Framework, Version=4.0")
+        public void SetDependencies(ICollection<ManifestDependency> manifestDependencies, string targetFramework)
         {
-            _manifest.Metadata.DependencySets =
-                new List<ManifestDependencySet>
-                {
-                    new ManifestDependencySet {Dependencies = manifestDependencies.ToList(), TargetFramework = targetFramework}
-                };
+            var manifestDependencySet = new ManifestDependencySet {Dependencies = manifestDependencies.ToList(), TargetFramework = targetFramework};
+            _manifest.Metadata.DependencySets = new List<ManifestDependencySet>{ manifestDependencySet };
         }
 
         public void Save(IConsole console)

--- a/NuGet.Extensions/ReferenceAnalysers/HintPathGenerator.cs
+++ b/NuGet.Extensions/ReferenceAnalysers/HintPathGenerator.cs
@@ -7,14 +7,18 @@ namespace NuGet.Extensions.ReferenceAnalysers
 {
     public class HintPathGenerator : IHintPathGenerator
     {
-        public HintPathGenerator()
-        {}
+        private readonly bool _useVersionedPackageHintPath;
+
+        public HintPathGenerator(bool useVersionedPackageHintPath = true)
+        {
+            _useVersionedPackageHintPath = useVersionedPackageHintPath;
+        }
 
         public string ForAssembly(DirectoryInfo solutionDir, DirectoryInfo projectDir, IPackage package, string assemblyFilename)
         {
             var fileLocation = GetFileLocationFromPackage(package, assemblyFilename);
-            //TODO make version available, currently only works for non versioned package directories...
-            var newHintPathFull = Path.Combine(solutionDir.FullName, "packages", package.Id, fileLocation);
+            var packageDirectory = _useVersionedPackageHintPath ? string.Format("{0}.{1}", package.Id, package.Version) : package.Id;
+            var newHintPathFull = Path.Combine(solutionDir.FullName, "packages", packageDirectory, fileLocation);
             var newHintPathRelative = GetRelativePath(projectDir.FullName + Path.DirectorySeparatorChar, newHintPathFull);
             return newHintPathRelative;
         }

--- a/NuGet.Extensions/ReferenceAnalysers/ProjectNugetifier.cs
+++ b/NuGet.Extensions/ReferenceAnalysers/ProjectNugetifier.cs
@@ -141,7 +141,7 @@ namespace NuGet.Extensions.ReferenceAnalysers
                 else if (GacResolver.AssemblyExist(reference.AssemblyName, out gacPath))
                 {
                     var publicKeyToken = GetPublicKeyTokenFromGacPath(gacPath);
-                    _console.WriteLine("Ignoring {0} because it was found in the GAC (with public key token {1})", reference.AssemblyName, publicKeyToken);
+                    WarnAboutIgnoredReference(reference, publicKeyToken);
                 }
                 else
                 {
@@ -150,6 +150,14 @@ namespace NuGet.Extensions.ReferenceAnalysers
             }
 
             return referenceFiles;
+        }
+
+        private void WarnAboutIgnoredReference(IReference reference, string publicKeyToken)
+        {
+            if (!PublicKeyTokens.UsedInNetFramework.Contains(publicKeyToken))
+            {
+                _console.WriteWarning("Ignoring {0} because it was found in the GAC (with public key token {1})", reference.AssemblyName, publicKeyToken);
+            }
         }
 
         private static string GetPublicKeyTokenFromGacPath(string hintPath)

--- a/NuGet.Extensions/ReferenceAnalysers/ProjectNugetifier.cs
+++ b/NuGet.Extensions/ReferenceAnalysers/ProjectNugetifier.cs
@@ -124,20 +124,36 @@ namespace NuGet.Extensions.ReferenceAnalysers
             return Enumerable.Empty<KeyValuePair<string, List<IPackage>>>();
         }
 
-        private static List<string> GetReferencedAssemblies(IEnumerable<IReference> references)
+        private List<string> GetReferencedAssemblies(IEnumerable<IReference> references)
         {
             var referenceFiles = new List<string>();
 
             foreach (var reference in references)
             {
-                //TODO deal with GAC assemblies that we want to replace as well....
                 string hintPath;
+                string gacPath;
                 if (reference.TryGetHintPath(out hintPath))
                 {
                     referenceFiles.Add(Path.GetFileName(hintPath));
                 }
+                else if (GacResolver.AssemblyExist(reference.AssemblyName, out gacPath))
+                {
+                    var publicKeyToken = GetPublicKeyTokenFromGacPath(gacPath);
+                    _console.WriteLine("Ignoring {0} because it was found in the GAC (with public key token {1})", reference.AssemblyName, publicKeyToken);
+                }
+                else
+                {
+                    referenceFiles.Add(reference.AssemblyName + ".dll");
+                }
             }
+
             return referenceFiles;
+        }
+
+        private static string GetPublicKeyTokenFromGacPath(string hintPath)
+        {
+            var versionUnderscoreToken = Path.GetDirectoryName(hintPath);
+            return versionUnderscoreToken.Split('_').Last();
         }
 
         public ICollection<ManifestDependency> GetManifestDependencies(ICollection<IPackage> packagesAdded)

--- a/NuGet.Extensions/ReferenceAnalysers/ProjectNugetifier.cs
+++ b/NuGet.Extensions/ReferenceAnalysers/ProjectNugetifier.cs
@@ -55,7 +55,9 @@ namespace NuGet.Extensions.ReferenceAnalysers
 
         private IEnumerable<IReference> GetReferences()
         {
-            return _vsProject.GetBinaryReferences();
+            var binaryReferences = _vsProject.GetBinaryReferences();
+            var projectReferences = _vsProject.GetProjectReferences();
+            return binaryReferences.Concat(projectReferences);
         }
 
         private void LogHintPathRewriteMessage(IPackage package, string includeName, string includeVersion)

--- a/NuGet.Extensions/ReferenceAnalysers/ProjectNugetifier.cs
+++ b/NuGet.Extensions/ReferenceAnalysers/ProjectNugetifier.cs
@@ -73,15 +73,15 @@ namespace NuGet.Extensions.ReferenceAnalysers
             else _console.WriteWarning(message);
         }
 
-        public void AddNugetReferenceMetadata(ISharedPackageRepository sharedPackagesRepository, ICollection<IPackage> packagesToAdd)
+        public void AddNugetReferenceMetadata(ISharedPackageRepository sharedPackagesRepository, ICollection<IPackage> packagesToAdd, FrameworkName targetFramework)
         {
             _console.WriteLine("Checking for any project references for {0}...", PackageReferenceFilename);
             if (!packagesToAdd.Any()) return;
-            CreatePackagesConfig(packagesToAdd);
+            CreatePackagesConfig(packagesToAdd, targetFramework);
             RegisterPackagesConfig(sharedPackagesRepository);
         }
 
-        private void CreatePackagesConfig(ICollection<IPackage> packagesToAdd, FrameworkName targetFramework = null)
+        private void CreatePackagesConfig(ICollection<IPackage> packagesToAdd, FrameworkName targetFramework)
         {
             _console.WriteLine("Creating {0}", PackageReferenceFilename);
             var packagesConfig = new PackageReferenceFile(_projectFileSystem, PackageReferenceFilename);

--- a/NuGet.Extensions/ReferenceAnalysers/PublicKeyTokens.cs
+++ b/NuGet.Extensions/ReferenceAnalysers/PublicKeyTokens.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace NuGet.Extensions.ReferenceAnalysers
+{
+    public static class PublicKeyTokens
+    {
+        private const string CompactFramework = "969db8053d3322ac";
+        private const string Ecma = "b03f5f7f11d50a3a";
+        private const string Framework = "b77a5c561934e089";
+        private const string Microsoft = "31bf3856ad364e35";
+        private const string Silverlight = "7cec85d7bea7798e";
+        private const string SomeSilverlight4 = "ddd0da4d3e678217";
+        private const string SomeWindowsPhone = "24eec0d8c86cda1e";
+        public static readonly HashSet<string> UsedInNetFramework = new HashSet<string> {CompactFramework, Ecma, Framework, Microsoft, Silverlight, SomeSilverlight4, SomeWindowsPhone};
+    }
+}


### PR DESCRIPTION
This a collection of improvements I found useful when converting large projects. This includes changing various defaults to match what someone used to NuGet might expect. It could be a minor inconvenience if anyone is relying on the old defaults, but hopefully makes the tool more useful overall.

If there are some bits you object to and other bits you're fine with let me know and I'll split them into multiple pull requests - or just cherry pick as appropriate.